### PR TITLE
Proposal: Docker plugins MVP

### DIFF
--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -1,5 +1,7 @@
 Brian Goff and Luke Marsden paired on an MVP of the plugin handshake interface.
 
+# pre-MVP design
+
 We ended up with the following design:
 
 ```
@@ -19,10 +21,58 @@ $ docker run -d -e $ARGS \
 
 Docker blocks on waiting for a successful handshake with the plugin on `/var/run/docker/plugin.sock` with an HTTP `POST /v1/handshake` with an empty body.
 
-Response:
+# Plugin API
+
+## `POST /v1/handshake`
+
+Request: POST with empty body
+Response: `application/json` as follows:
+
 ```
 {
  InterestedIn: ["volume"],
- PluginName: "flocker"
+ PluginName: "flocker",
+ PluginAuthor: "Luke Marsden <luke@clusterhq.com>",
+ PluginOrg: "ClusterHQ, Inc.",
+ PluginWebsite: "https://clusterhq.com/",
 }
 ```
+
+PluginName is a human readable short string identifying the plugin.
+
+InterestedIn is a list of extension points.
+
+Extension points currently supported are:
+
+* volume - called when a volume is bind-mounted into a container at create or start time
+
+Planned extension points include:
+
+* api - pre-hooks and post-hooks on the Docker remote API (powerstrip-style)
+* network - called when ???
+
+## `POST /v1/volume/volumes`
+
+The simplest of plugin types, `volume` provides a single request-response type on `POST /v1/volume/volumes` (`POST ~= create`):
+
+**Request**
+
+```
+{HostPath: "/path",
+ ContainerID: "abcdef123"}
+```
+
+**Response**
+
+```
+{HostPath: "/newpath",
+ ContainerID: "abcdef123"}
+```
+
+NB: plugin loading order is undefined, so plugins should not depend on eachother.
+
+---
+
+TODO
+
+* sort out plugins from normal containers and load plugins first so that containers that want to use services (e.g. portable volumes) from containers get to consume those services from other plugins.

--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -12,10 +12,17 @@ Internally this translates into:
 
 ```
 $ docker run -d -e $ARGS \
-	-v /var/lib/docker/containers/<container_id>/plugin/plugin.sock:/var/run/docker/plugin.sock \
+	-v /var/lib/docker/containers/<container_id>/plugin/:/var/run/docker/ \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	clusterhq/flocker-plugin $@
 ```
 
-Docker blocks on waiting for a successful handshake with the plugin.
+Docker blocks on waiting for a successful handshake with the plugin on `/var/run/docker/plugin.sock` with an HTTP `POST /v1/handshake` with an empty body.
 
+Response:
+```
+{
+ InterestedIn: ["volume"],
+ PluginName: "flocker"
+}
+```

--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -10,13 +10,15 @@ $ docker run --plugin \
     clusterhq/flocker-plugin
 ```
 
+Note the new `--plugin` argument.
+
 Internally this translates into:
 
 ```
-$ docker run -d -e $ARGS \
+$ docker run -d \
 	-v /var/lib/docker/containers/<container_id>/plugin/:/var/run/docker/ \
 	-v /var/run/docker.sock:/var/run/docker.sock \
-	clusterhq/flocker-plugin $@
+	clusterhq/flocker-plugin
 ```
 
 Docker blocks on waiting for a successful handshake with the plugin on `/var/run/docker/plugin.sock` with an HTTP `POST /v1/handshake` with an empty body.

--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -34,10 +34,10 @@ Docker blocks on waiting for a successful handshake with the plugin on `/var/run
 ```
 {
  InterestedIn: ["volume"],
- PluginName: "flocker",
- PluginAuthor: "Luke Marsden <luke@clusterhq.com>",
- PluginOrg: "ClusterHQ, Inc.",
- PluginWebsite: "https://clusterhq.com/",
+ Name: "flocker",
+ Author: "Luke Marsden <luke@clusterhq.com>",
+ Org: "ClusterHQ, Inc.",
+ Website: "https://clusterhq.com/",
 }
 ```
 
@@ -75,6 +75,10 @@ The simplest of plugin types, `volume` provides a single request-response type o
 # Caveats
 
 NB: plugin loading order is undefined, so plugins should not depend on eachother.
+
+# Versioning strategy
+
+When we bump `/v1/handshake` to `/v2/handshake` etc, we can have Docker start by trying to do the highest numbered handshake it can, and then iterate backwards through supported handshake versions until it finds one which matches (ie does not give a 404).
 
 ---
 

--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -25,8 +25,9 @@ Docker blocks on waiting for a successful handshake with the plugin on `/var/run
 
 ## `POST /v1/handshake`
 
-Request: POST with empty body
-Response: `application/json` as follows:
+**Request:** POST with empty body
+
+**Response:** `application/json` as follows:
 
 ```
 {
@@ -68,6 +69,8 @@ The simplest of plugin types, `volume` provides a single request-response type o
 {HostPath: "/newpath",
  ContainerID: "abcdef123"}
 ```
+
+# Caveats
 
 NB: plugin loading order is undefined, so plugins should not depend on eachother.
 

--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -1,0 +1,21 @@
+Brian Goff and Luke Marsden paired on an MVP of the plugin handshake interface.
+
+We ended up with the following design:
+
+```
+$ docker run --plugin \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    clusterhq/flocker-plugin
+```
+
+Internally this translates into:
+
+```
+$ docker run -d -e $ARGS \
+	-v /var/lib/docker/containers/<container_id>/plugin/plugin.sock:/var/run/docker/plugin.sock \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	clusterhq/flocker-plugin $@
+```
+
+Docker blocks on waiting for a successful handshake with the plugin.
+

--- a/docs/sources/reference/plugin-mvp.md
+++ b/docs/sources/reference/plugin-mvp.md
@@ -39,18 +39,18 @@ Docker blocks on waiting for a successful handshake with the plugin on `/var/run
 }
 ```
 
-PluginName is a human readable short string identifying the plugin.
+`PluginName` is a human readable short string identifying the plugin.
 
-InterestedIn is a list of extension points.
+`InterestedIn` is a list of extension points.
 
 Extension points currently supported are:
 
-* volume - called when a volume is bind-mounted into a container at create or start time
+* `volume` - called when a volume is bind-mounted into a container at create or start time
 
 Planned extension points include:
 
-* api - pre-hooks and post-hooks on the Docker remote API (powerstrip-style)
-* network - called when ???
+* `api` - pre-hooks and post-hooks on the Docker remote API (powerstrip-style)
+* `network` - called when ???
 
 ## `POST /v1/volume/volumes`
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -69,7 +69,7 @@ The simplest of plugin types, `volume` provides a single request-response type o
  ContainerID: "abcdef123"}
 ```
 
-In the initial version, if the plugin responds with an empty string (`""`) as the `ModifiedHostPath`, the response is ignored.
+In the initial version, if the plugin responds with a 404 then the response is ignored.
 
 See reference implementation:
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -7,6 +7,8 @@ HTTP over a local UNIX socket is used to communicate between Docker and its plug
 
 Plugins are distributed as containers.
 
+This is targeted at Docker 1.7.
+
 # Usage
 
 Plugins can be loaded using a special `docker plugin load` command, as follows:

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -25,7 +25,7 @@ This is really just syntactic sugar for the following:
 
 ```
 $ docker run -d -e $ARGS \
-	-v /var/lib/docker/.../<container_id>/plugin.sock:/var/run/docker/plugin.sock \
+	-v /var/lib/docker/containers/<container_id>/plugin/:/var/run/docker/ \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	clusterhq/flocker-plugin $@
 ```
@@ -34,14 +34,13 @@ $ docker run -d -e $ARGS \
 
 Loading a plugin forces it to always be loaded when Docker restarts (and Docker doesn't respond to API requests until it completes loading all its plugins).
 
-Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in - response defined below).
+Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in - response defined below).
 According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
 
 Plugins should name themselves in the response, which should be in this format:
 
 ```
 {
- DockerPluginHandshakeVersion: 1,
  InterestedIn: ["volume"],
  PluginName: "flocker"
 }

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -30,6 +30,8 @@ $ docker run -d -e $ARGS \
 
 (The docker socket should only be mounted if the plugin is started with `--privileged`.)
 
+Loading a plugin forces it to always be loaded when Docker restarts (and Docker doesn't respond to API requests until it completes loading all its plugins).
+
 Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
 
 Other `plugin` subcommands can include `list`, `status`, `upgrade`, and `unload`.

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -22,7 +22,7 @@ Plugin flocker activated.
 This is really just syntactic sugar for the following:
 
 ```
-$ docker run -d -e PLUGIN_TYPE=volume -e PLUGIN_NAME=flocker \
+$ docker run -d -e \
 	-v /var/run/docker-plugins/flocker.sock:/var/run/plugin.sock \
 	clusterhq/flocker-plugin
 ```
@@ -86,7 +86,7 @@ In future, we will want to extend this to notify volume extensions when containe
 We may want to extend the volumes CLI in due course, so you can do something like the following:
 
 ```
-$ docker volume create nicevol --size=50G --tier=ssd --replication=global
+$ docker volume create --size=50G --tier=ssd --replication=global nicevol
 $ docker run -v //nicevol:/data dockerfile/postgresql
 ```
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -28,7 +28,7 @@ $ docker run -d -e $ARGS \
 	clusterhq/flocker-plugin $@
 ```
 
-(The docker socket should only be mounted if the plugin is started with `--priviliged`.)
+(The docker socket should only be mounted if the plugin is started with `--privileged`.)
 
 Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -25,7 +25,7 @@ This is really just syntactic sugar for the following:
 
 ```
 $ docker run -d -e $ARGS \
-	-v /var/run/docker-plugins/flocker.sock:/var/run/plugin.sock \
+	-v /var/lib/docker/.../<container_id>/plugin.sock:/var/run/docker/plugin.sock \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	clusterhq/flocker-plugin $@
 ```
@@ -40,8 +40,11 @@ According to the type of plugin which is negotiated in the handshake, Docker reg
 Plugins should name themselves in the response, which should be in this format:
 
 ```
-{InterestedIn: ["volume"],
- PluginName: "flocker"}
+{
+ DockerPluginHandshakeVersion: 1,
+ InterestedIn: ["volume"],
+ PluginName: "flocker"
+}
 ```
 
 Every event should be sent to every plugin registered for that subsystem for now.

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -53,6 +53,8 @@ Each plugin type defines a straightforward (MVP) protocol.
 
 ## Volume
 
+We will start with this first because it is has the tiniest interface.
+
 The simplest of plugin types, `volume` provides a single request-response type on `POST /v1/volumes` (`POST ~= create`):
 
 **Request**

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -12,7 +12,7 @@ Plugins are distributed as containers.
 Plugins can be loaded using a special `docker plugin load` command, as follows:
 
 ```
-$ docker plugin load clusterhq/flocker-plugin:v0.1
+$ docker plugin load clusterhq/flocker-plugin
 [... fetching...]
 Plugin flocker:v0.1 loaded and registered with extension points:
 * volumes
@@ -28,6 +28,8 @@ $ docker run -d -e PLUGIN_TYPE=volume -e PLUGIN_NAME=flocker \
 ```
 
 Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
+
+Other `plugin` subcommands can include `list`, `status`, `upgrade`, and `unload`.
 
 # Types of plugin
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -129,7 +129,6 @@ This area needs fleshing out.
 
 * While waiting for the plugin to initialize, Docker should not allow any API requests to succeed.
   This is to avoid startup race where e.g. `create` requests might not get passed through the plugins.
-* Plugins could negotiate with Docker via an initial handshake HTTP request.
 * Plugins could use a protocol other than HTTP.
 * Loading a plugin marks the plugin's container as hidden from `docker ps`.
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -22,10 +22,13 @@ Plugin flocker activated.
 This is really just syntactic sugar for the following:
 
 ```
-$ docker run -d -e \
+$ docker run -d \
 	-v /var/run/docker-plugins/flocker.sock:/var/run/plugin.sock \
+	-v /var/run/docker.sock:/var/run/docker.sock \
 	clusterhq/flocker-plugin
 ```
+
+(The docker socket should only be mounted if the plugin is started with `--priviliged`.)
 
 Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -32,7 +32,7 @@ $ docker run -d -e $ARGS \
 
 Loading a plugin forces it to always be loaded when Docker restarts (and Docker doesn't respond to API requests until it completes loading all its plugins).
 
-Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
+Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in: `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
 
 Other `plugin` subcommands can include `list`, `status`, `upgrade`, and `unload`.
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -97,7 +97,7 @@ In future, we will want to extend this to notify volume extensions when containe
 
 ### Volumes CLI
 
-We may want to extend the volumes CLI in due course, so you can do something like the following:
+We may want to extend some (as-yet non-existent) docker core volumes CLI in due course, so you can do something like the following:
 
 ```
 $ docker volume create --driver flocker \

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -86,8 +86,9 @@ In future, we will want to extend this to notify volume extensions when containe
 We may want to extend the volumes CLI in due course, so you can do something like the following:
 
 ```
-$ docker volume create --size=50G --tier=ssd --replication=global nicevol
-$ docker run -v //nicevol:/data dockerfile/postgresql
+$ docker volume create --driver flocker \
+	--metadata size=50G,tier=ssd,replication=global nicevol
+$ docker run -v /flocker/nicevol:/data dockerfile/postgresql
 ```
 
 This would result in similar API requests being made.

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -32,7 +32,19 @@ $ docker run -d -e $ARGS \
 
 Loading a plugin forces it to always be loaded when Docker restarts (and Docker doesn't respond to API requests until it completes loading all its plugins).
 
-Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in: `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
+Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in - response defined below).
+According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
+
+Plugins should name themselves in the response, which should be in this format:
+
+```
+{PluginNegotiationVersion: 1,
+ InterestedIn: ["volume"],
+ PluginName: "flocker",
+```
+
+Every event should be sent to every plugin registered for that subsystem for now.
+Later the handshake can include more granular negotiation over which events it wants to receive.
 
 Other `plugin` subcommands can include `list`, `status`, `upgrade`, and `unload`.
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -1,0 +1,88 @@
+# Docker Plugins MVP
+
+Plugins provide a mechanism for hooking into the Docker engine to extend its behavior.
+
+HTTP over a local UNIX socket is used to communicate between Docker and its plugins.
+
+Plugins are distributed as containers.
+
+## Usage
+
+Plugins can be loaded using a special `docker plugin-load` command, as follows:
+
+```
+$ docker plugin-load volume:flocker clusterhq/flocker-plugin
+```
+
+This is really just syntactic sugar for the following:
+
+```
+$ docker run -d -e PLUGIN_TYPE=volume -e PLUGIN_NAME=flocker \
+	-v /var/run/docker-plugins/flocker.sock:/var/run/plugin.sock \
+	clusterhq/flocker-plugin
+```
+
+It also marks the plugin container as hidden from `docker ps`.
+
+Docker then waits for the plugin to start listening on the socket, and according to the type of plugin, sends it HTTP requests on certain events.
+
+## Types of plugin
+
+Each plugin type defines a straightforward (MVP) protocol.
+
+### Volume
+
+The simplest of plugin types, `volume` provides a single request-response type:
+
+**Request**
+
+```
+{DockerVolumesExtensionVersion: 1,
+ Action: "create",
+ HostPath: "/path",
+ ContainerID: "abcdef123",
+}
+```
+
+**Response**
+
+```
+{DockerVolumesExtensionVersion: 1,
+ ModifiedHostPath: "/newpath"} 
+```
+
+In the initial version, if the plugin responds with an empty string (`""`) as the `ModifiedHostPath`, the response is ignored.
+
+See reference implementation:
+* https://github.com/cpuguy83/docker/compare/ddb366ee9a07e3feab766cc712c9683ad0c3c309
+* https://github.com/ClusterHQ/powerstrip-flocker/compare/docker-volume-extension
+
+**Demo**
+
+```
+$ git clone https://github.com/clusterhq/powerstrip-flocker
+$ cd powerstrip-flocker/vagrant-aws
+$ git checkout docker-volume-extension
+$ vagrant up --provider=aws
+$ vagrant ssh node1
+node1$ docker run -v /flocker/test:/data ubuntu sh -c "echo fish > /data/file.txt"
+node1$ exit
+$ vagrant ssh node2
+node2$ docker run -v /flocker/test:/data ubuntu cat /data/file.txt
+fish
+```
+
+### API
+
+
+
+### Network
+
+???
+
+## Possible future functionality
+
+* While waiting for the plugin to initialize, Docker should not allow any API requests to succeed.
+  This is to avoid startup race where e.g. `create` requests might not get passed through the plugins.
+* Plugins could negotiate with Docker via an initial handshake HTTP request.
+* Plugins could use a protocol other than HTTP.

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -9,10 +9,14 @@ Plugins are distributed as containers.
 
 # Usage
 
-Plugins can be loaded using a special `docker plugin-load` command, as follows:
+Plugins can be loaded using a special `docker plugin load` command, as follows:
 
 ```
-$ docker plugin-load volume:flocker clusterhq/flocker-plugin
+$ docker plugin load clusterhq/flocker-plugin:v0.1
+[... fetching...]
+Plugin flocker:v0.1 loaded and registered with extension points:
+* volumes
+Plugin flocker activated.
 ```
 
 This is really just syntactic sugar for the following:
@@ -23,7 +27,7 @@ $ docker run -d -e PLUGIN_TYPE=volume -e PLUGIN_NAME=flocker \
 	clusterhq/flocker-plugin
 ```
 
-Docker then waits for the plugin to start listening on the socket, and according to the type of plugin, sends it HTTP requests on certain events.
+Docker then waits for the plugin to start listening on the socket (it polls the socket until it gets a successful response to an HTTP query to `/v1/plugin/handshake` on the socket, which returns with just a list of subsystems the plugin is interested in `["volume"]`). According to the type of plugin which is negotiated in the handshake, Docker registers the plugin to send it HTTP requests on certain events.
 
 # Types of plugin
 

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -38,9 +38,8 @@ According to the type of plugin which is negotiated in the handshake, Docker reg
 Plugins should name themselves in the response, which should be in this format:
 
 ```
-{PluginNegotiationVersion: 1,
- InterestedIn: ["volume"],
- PluginName: "flocker",
+{InterestedIn: ["volume"],
+ PluginName: "flocker"}
 ```
 
 Every event should be sent to every plugin registered for that subsystem for now.
@@ -54,22 +53,20 @@ Each plugin type defines a straightforward (MVP) protocol.
 
 ## Volume
 
-The simplest of plugin types, `volume` provides a single request-response type:
+The simplest of plugin types, `volume` provides a single request-response type on `POST /v1/volumes` (`POST ~= create`):
 
 **Request**
 
 ```
-{DockerVolumesExtensionVersion: 1,
- Action: "create",
- HostPath: "/path",
+{HostPath: "/path",
  ContainerID: "abcdef123"}
 ```
 
 **Response**
 
 ```
-{DockerVolumesExtensionVersion: 1,
- ModifiedHostPath: "/newpath"} 
+{HostPath: "/newpath",
+ ContainerID: "abcdef123"}
 ```
 
 In the initial version, if the plugin responds with an empty string (`""`) as the `ModifiedHostPath`, the response is ignored.

--- a/docs/sources/userguide/plugins.md
+++ b/docs/sources/userguide/plugins.md
@@ -12,7 +12,7 @@ Plugins are distributed as containers.
 Plugins can be loaded using a special `docker plugin load` command, as follows:
 
 ```
-$ docker plugin load clusterhq/flocker-plugin
+$ docker plugin load -e $ARGS clusterhq/flocker-plugin $@
 [... fetching...]
 Plugin flocker:v0.1 loaded and registered with extension points:
 * volumes
@@ -22,10 +22,10 @@ Plugin flocker activated.
 This is really just syntactic sugar for the following:
 
 ```
-$ docker run -d \
+$ docker run -d -e $ARGS \
 	-v /var/run/docker-plugins/flocker.sock:/var/run/plugin.sock \
 	-v /var/run/docker.sock:/var/run/docker.sock \
-	clusterhq/flocker-plugin
+	clusterhq/flocker-plugin $@
 ```
 
 (The docker socket should only be mounted if the plugin is started with `--priviliged`.)


### PR DESCRIPTION
Here is a proposal for an MVP for docker plugins that unifies all the efforts in this direction.

Note that there are now - as of Monday :) three types of prototypical docker plugins:

* Volume plugins - using HTTP as extension mechanism
* Networking plugins - using an undefined extension mechanism
* API plugins - aka "powerstrip" - using HTTP as extension mechanism

This proposal suggests that we standardize on HTTP for an initial pass on the plugins framework.
For purely local plugins using a UNIX domain socket, this is sufficiently secure.

Powerstrip has demonstrated that HTTP makes it very easy for plugin authors to get started.

I suggest we could then iterate on this choice of transport once we've got some experience prototyping these plugins.

More important is getting rough consensus and running code after agreeing the message formats that need to be sent and received between docker and plugins for volumes, networking & API extensions.