### PR TITLE
Add support for reading journal extra fields

### DIFF
--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -25,6 +25,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	follow := cmd.Bool([]string{"f", "-follow"}, false, "Follow log output")
 	since := cmd.String([]string{"-since"}, "", "Show logs since timestamp")
 	times := cmd.Bool([]string{"t", "-timestamps"}, false, "Show timestamps")
+	details := cmd.Bool([]string{"-details"}, false, "Show extra details provided to logs")
 	tail := cmd.String([]string{"-tail"}, "all", "Number of lines to show from the end of the logs")
 	cmd.Require(flag.Exact, 1)
 
@@ -48,6 +49,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		Timestamps: *times,
 		Follow:     *follow,
 		Tail:       *tail,
+		Details:    *details,
 	}
 	responseBody, err := cli.client.ContainerLogs(context.Background(), name, options)
 	if err != nil {

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -99,6 +99,7 @@ func (s *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 			Tail:       r.Form.Get("tail"),
 			ShowStdout: stdout,
 			ShowStderr: stderr,
+			Details:    httputils.BoolValue(r, "details"),
 		},
 		OutStream: w,
 	}

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -50,6 +50,53 @@ package journald
 //	}
 //	return rc;
 //}
+//static int is_relevant_field(const char *msg, size_t length)
+//{
+//	const struct relevant {
+//		const char *name;
+//		size_t length;
+//	} fields[] = {
+//		{"MESSAGE", sizeof("MESSAGE") - 1},
+//		{"MESSAGE_ID", sizeof("MESSAGE_ID") - 1},
+//		{"PRIORITY", sizeof("PRIORITY") - 1},
+//		{"CODE_FILE", sizeof("CODE_FILE") - 1},
+//		{"CODE_LINE", sizeof("CODE_LINE") - 1},
+//		{"CODE_FUNC", sizeof("CODE_FUNC") - 1},
+//		{"ERRNO", sizeof("ERRNO") - 1},
+//		{"SYSLOG_FACILITY", sizeof("SYSLOG_FACILITY") - 1},
+//		{"SYSLOG_IDENTIFIER", sizeof("SYSLOG_IDENTIFIER") - 1},
+//		{"SYSLOG_PID", sizeof("SYSLOG_PID") - 1},
+//		{"CONTAINER_NAME", sizeof("CONTAINER_NAME") - 1},
+//		{"CONTAINER_ID", sizeof("CONTAINER_ID") - 1},
+//		{"CONTAINER_ID_FULL", sizeof("CONTAINER_ID_FULL") - 1},
+//		{"CONTAINER_TAG", sizeof("CONTAINER_TAG") - 1},
+//	};
+//	unsigned int i;
+//	void *p;
+//	if ((length < 1) || (msg[0] == '_') || ((p = memchr(msg, '=', length)) == NULL)) {
+//		return -1;
+//	}
+//	length = ((const char *) p) - msg;
+//	for (i = 0; i < sizeof(fields) / sizeof(fields[0]); i++) {
+//		if ((fields[i].length == length) && (memcmp(fields[i].name, msg, length) == 0)) {
+//			return -1;
+//		}
+//	}
+//	return 0;
+//}
+//static int get_relevant_field(sd_journal *j, const char **msg, size_t *length)
+//{
+//	int rc;
+//	*msg = NULL;
+//	*length = 0;
+//	while ((rc = sd_journal_enumerate_data(j, (const void **) msg, length)) > 0) {
+//		if (is_relevant_field(*msg, *length) == 0) {
+//			break;
+//		}
+//		rc = -ENOENT;
+//	}
+//	return rc;
+//}
 //static int wait_for_data_or_close(sd_journal *j, int pipefd)
 //{
 //	struct pollfd fds[2];
@@ -98,6 +145,7 @@ import "C"
 
 import (
 	"fmt"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -116,7 +164,7 @@ func (s *journald) Close() error {
 }
 
 func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.ReadConfig, j *C.sd_journal, oldCursor string) string {
-	var msg, cursor *C.char
+	var msg, data, cursor *C.char
 	var length C.size_t
 	var stamp C.uint64_t
 	var priority C.int
@@ -156,9 +204,19 @@ drain:
 			} else if priority == C.int(journal.PriInfo) {
 				source = "stdout"
 			}
+			// Retrieve the values of any variables we're adding to the journal.
+			attrs := make(map[string]string)
+			C.sd_journal_restart_data(j)
+			for C.get_relevant_field(j, &data, &length) > C.int(0) {
+				kv := strings.SplitN(C.GoStringN(data, C.int(length)), "=", 2)
+				attrs[kv[0]] = kv[1]
+			}
+			if len(attrs) == 0 {
+				attrs = nil
+			}
 			// Send the log message.
 			cid := s.vars["CONTAINER_ID_FULL"]
-			logWatcher.Msg <- &logger.Message{ContainerID: cid, Line: line, Source: source, Timestamp: timestamp}
+			logWatcher.Msg <- &logger.Message{ContainerID: cid, Line: line, Source: source, Timestamp: timestamp, Attrs: attrs}
 		}
 		// If we're at the end of the journal, we're done (for now).
 		if C.sd_journal_next(j) <= 0 {

--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -27,6 +27,7 @@ func decodeLogLine(dec *json.Decoder, l *jsonlog.JSONLog) (*logger.Message, erro
 		Source:    l.Stream,
 		Timestamp: l.Created,
 		Line:      []byte(l.Log),
+		Attrs:     l.Attrs,
 	}
 	return msg, nil
 }

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -9,6 +9,8 @@ package logger
 
 import (
 	"errors"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/pkg/jsonlog"
@@ -29,6 +31,31 @@ type Message struct {
 	Line        []byte
 	Source      string
 	Timestamp   time.Time
+	Attrs       LogAttributes
+}
+
+// LogAttributes is used to hold the extra attributes available in the log message
+// Primarily used for converting the map type to string and sorting.
+type LogAttributes map[string]string
+type byKey []string
+
+func (s byKey) Len() int { return len(s) }
+func (s byKey) Less(i, j int) bool {
+	keyI := strings.Split(s[i], "=")
+	keyJ := strings.Split(s[j], "=")
+	return keyI[0] < keyJ[0]
+}
+func (s byKey) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (a LogAttributes) String() string {
+	var ss byKey
+	for k, v := range a {
+		ss = append(ss, k+"="+v)
+	}
+	sort.Sort(ss)
+	return strings.Join(ss, ",")
 }
 
 // Logger is the interface for docker logging drivers.

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -90,6 +90,9 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 				return nil
 			}
 			logLine := msg.Line
+			if config.Details {
+				logLine = append([]byte(msg.Attrs.String()+" "), logLine...)
+			}
 			if config.Timestamps {
 				logLine = append([]byte(msg.Timestamp.Format(logger.TimeFormat)+" "), logLine...)
 			}

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -307,3 +307,16 @@ func (s *DockerSuite) TestLogsCLIContainerNotFound(c *check.C) {
 	message := fmt.Sprintf("Error: No such container: %s\n", name)
 	c.Assert(out, checker.Equals, message)
 }
+
+func (s *DockerSuite) TestLogsWithDetails(c *check.C) {
+	dockerCmd(c, "run", "--name=test", "--label", "foo=bar", "-e", "baz=qux", "--log-opt", "labels=foo", "--log-opt", "env=baz", "busybox", "echo", "hello")
+	out, _ := dockerCmd(c, "logs", "--details", "--timestamps", "test")
+
+	logFields := strings.Fields(strings.TrimSpace(out))
+	c.Assert(len(logFields), checker.Equals, 3, check.Commentf(out))
+
+	details := strings.Split(logFields[1], ",")
+	c.Assert(details, checker.HasLen, 2)
+	c.Assert(details[0], checker.Equals, "baz=qux")
+	c.Assert(details[1], checker.Equals, "foo=bar")
+}

--- a/pkg/jsonlog/jsonlog.go
+++ b/pkg/jsonlog/jsonlog.go
@@ -15,6 +15,8 @@ type JSONLog struct {
 	Stream string `json:"stream,omitempty"`
 	// Created is the created timestamp of log
 	Created time.Time `json:"time"`
+	// Attrs is the list of extra attributes provided by the user
+	Attrs map[string]string `json:"attrs,omitempty"`
 }
 
 // Format returns the log formatted according to format

--- a/pkg/jsonlog/jsonlog_marshalling_test.go
+++ b/pkg/jsonlog/jsonlog_marshalling_test.go
@@ -6,18 +6,18 @@ import (
 )
 
 func TestJSONLogMarshalJSON(t *testing.T) {
-	logs := map[JSONLog]string{
-		JSONLog{Log: `"A log line with \\"`}:           `^{\"log\":\"\\\"A log line with \\\\\\\\\\\"\",\"time\":\".{20,}\"}$`,
-		JSONLog{Log: "A log line"}:                     `^{\"log\":\"A log line\",\"time\":\".{20,}\"}$`,
-		JSONLog{Log: "A log line with \r"}:             `^{\"log\":\"A log line with \\r\",\"time\":\".{20,}\"}$`,
-		JSONLog{Log: "A log line with & < >"}:          `^{\"log\":\"A log line with \\u0026 \\u003c \\u003e\",\"time\":\".{20,}\"}$`,
-		JSONLog{Log: "A log line with utf8 : 🚀 ψ ω β"}: `^{\"log\":\"A log line with utf8 : 🚀 ψ ω β\",\"time\":\".{20,}\"}$`,
-		JSONLog{Stream: "stdout"}:                      `^{\"stream\":\"stdout\",\"time\":\".{20,}\"}$`,
-		JSONLog{}:                                      `^{\"time\":\".{20,}\"}$`,
+	logs := map[*JSONLog]string{
+		&JSONLog{Log: `"A log line with \\"`}:           `^{\"log\":\"\\\"A log line with \\\\\\\\\\\"\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: "A log line"}:                     `^{\"log\":\"A log line\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: "A log line with \r"}:             `^{\"log\":\"A log line with \\r\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: "A log line with & < >"}:          `^{\"log\":\"A log line with \\u0026 \\u003c \\u003e\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: "A log line with utf8 : 🚀 ψ ω β"}: `^{\"log\":\"A log line with utf8 : 🚀 ψ ω β\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Stream: "stdout"}:                      `^{\"stream\":\"stdout\",\"time\":\".{20,}\"}$`,
+		&JSONLog{}:                                      `^{\"time\":\".{20,}\"}$`,
 		// These ones are a little weird
-		JSONLog{Log: "\u2028 \u2029"}:      `^{\"log\":\"\\u2028 \\u2029\",\"time\":\".{20,}\"}$`,
-		JSONLog{Log: string([]byte{0xaF})}: `^{\"log\":\"\\ufffd\",\"time\":\".{20,}\"}$`,
-		JSONLog{Log: string([]byte{0x7F})}: `^{\"log\":\"\x7f\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: "\u2028 \u2029"}:      `^{\"log\":\"\\u2028 \\u2029\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: string([]byte{0xaF})}: `^{\"log\":\"\\ufffd\",\"time\":\".{20,}\"}$`,
+		&JSONLog{Log: string([]byte{0x7F})}: `^{\"log\":\"\x7f\",\"time\":\".{20,}\"}$`,
 	}
 	for jsonLog, expression := range logs {
 		data, err := jsonLog.MarshalJSON()

--- a/vendor/src/github.com/docker/engine-api/client/container_logs.go
+++ b/vendor/src/github.com/docker/engine-api/client/container_logs.go
@@ -35,6 +35,10 @@ func (cli *Client) ContainerLogs(ctx context.Context, container string, options 
 		query.Set("timestamps", "1")
 	}
 
+	if options.Details {
+		query.Set("details", "1")
+	}
+
 	if options.Follow {
 		query.Set("follow", "1")
 	}

--- a/vendor/src/github.com/docker/engine-api/types/client.go
+++ b/vendor/src/github.com/docker/engine-api/types/client.go
@@ -57,6 +57,7 @@ type ContainerLogsOptions struct {
 	Timestamps bool
 	Follow     bool
 	Tail       string
+	Details    bool
 }
 
 // ContainerRemoveOptions holds parameters to remove containers.


### PR DESCRIPTION
As mentioned in https://github.com/docker/docker/pull/21889/, these changes should let the journald reader fill in data fields from journal entries that aren't present by default and which we aren't adding in the journald log driver.