### PR TITLE
review suggestions for moby#47239

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -97,6 +97,10 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 				info.Runtimes[k] = system.RuntimeWithStatus{Runtime: rt.Runtime}
 			}
 		}
+		if versions.LessThan(version, "1.46") {
+			// Containerd field introduced in API v1.46.
+			info.Containerd = nil
+		}
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5814,27 +5814,50 @@ definitions:
     description: |
       Information for connecting to the containerd instance that is used by the daemon.
       This is included for debugging purposes only.
-      Tampering with the containerd instance may cause unexpected behavior.
     type: "object"
     properties:
       Address:
         description: "The address of the containerd socket."
         type: "string"
+        example: "/run/containerd/containerd.sock"
       Namespaces:
-        description: "The namespaces that are used by containerd."
+        description: |
+          The namespaces that the daemon uses for running containers and
+          plugins in containerd. These namespaces can be configured in the
+          daemon configuration, and are considered to be used exclusively 
+          by the daemon, Tampering with the containerd instance may cause
+          unexpected behavior.
+
+          As these namespaces are considered to be exclusively accessed
+          by the daemon, it is not recommended to change these values,
+          or to change them to a value that is used by other systems,
+          such as cri-containerd.
         type: "object"
         properties:
           Containers:
-            description: "The namespace that is used for containers."
+            description: |
+              The default containerd namespace used for containers managed
+              by the daemon.
+              
+              The default namespace for containers is "moby", but will be
+              suffixed with the `<uid>.<gid>` of the remapped `root` if
+              user-namespaces are enabled and the containerd image-store
+              is used.
             type: "string"
+            default: "moby"
+            example: "moby"
           Plugins:
-            description: "The namespace that is used for plugins."
+            description: |
+              The default containerd namespace used for plugins managed by
+              the daemon.
+
+              The default namespace for plugins is "plugins.moby", but will be
+              suffixed with the `<uid>.<gid>` of the remapped `root` if
+              user-namespaces are enabled and the containerd image-store
+              is used.
             type: "string"
-    example:
-      Address: "/run/containerd/containerd.sock"
-      Namespaces:
-        Containers: "moby"
-        Plugins: "plugins.moby"
+            default: "plugins.moby"
+            example: "plugins.moby"
 
   # PluginsInfo is a temp struct holding Plugins name
   # registered with docker daemon. It is used by Info struct

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -96,9 +96,32 @@ type ContainerdInfo struct {
 }
 
 // ContainerdNamespaces reflects the containerd namespaces used by the daemon.
+//
+// These namespaces can be configured in the daemon configuration, and are
+// considered to be used exclusively by the daemon,
+//
+// As these namespaces are considered to be exclusively accessed
+// by the daemon, it is not recommended to change these values,
+// or to change them to a value that is used by other systems,
+// such as cri-containerd.
 type ContainerdNamespaces struct {
+	// Containers holds the default containerd namespace used for
+	// containers managed by the daemon.
+	//
+	// The default namespace for containers is "moby", but will be
+	// suffixed with the `<uid>.<gid>` of the remapped `root` if
+	// user-namespaces are enabled and the containerd image-store
+	// is used.
 	Containers string
-	Plugins    string
+
+	// Plugins holds the default containerd namespace used for
+	// plugins managed by the daemon.
+	//
+	// The default namespace for plugins is "moby", but will be
+	// suffixed with the `<uid>.<gid>` of the remapped `root` if
+	// user-namespaces are enabled and the containerd image-store
+	// is used.
+	Plugins string
 }
 
 type legacyFields struct {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -82,7 +82,9 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 
 	daemon.fillContainerStates(v)
 	daemon.fillDebugInfo(ctx, v)
+	daemon.fillContainerdInfo(v, &cfg.Config)
 	daemon.fillAPIInfo(v, &cfg.Config)
+
 	// Retrieve platform specific info
 	if err := daemon.fillPlatformInfo(ctx, v, sysInfo, cfg); err != nil {
 		return nil, err
@@ -228,15 +230,20 @@ func (daemon *Daemon) fillDebugInfo(ctx context.Context, v *system.Info) {
 	v.NGoroutines = runtime.NumGoroutine()
 	v.NEventsListener = daemon.EventsService.SubscribersCount()
 
-	config := daemon.Config()
-	if config.ContainerdAddr != "" {
-		v.Containerd = &system.ContainerdInfo{
-			Address: config.ContainerdAddr,
-			Namespaces: system.ContainerdNamespaces{
-				Containers: config.ContainerdNamespace,
-				Plugins:    config.ContainerdPluginNamespace,
-			},
-		}
+}
+
+// fillContainerdInfo provides information about the containerd configuration
+// for debugging purposes.
+func (daemon *Daemon) fillContainerdInfo(v *system.Info, cfg *config.Config) {
+	if cfg.ContainerdAddr == "" {
+		return
+	}
+	v.Containerd = &system.ContainerdInfo{
+		Address: cfg.ContainerdAddr,
+		Namespaces: system.ContainerdNamespaces{
+			Containers: cfg.ContainerdNamespace,
+			Plugins:    cfg.ContainerdPluginNamespace,
+		},
 	}
 }
 


### PR DESCRIPTION
- for https://github.com/moby/moby/pull/47239

### integration/container: TestContainerdContainerImageInfo: adjust API version

The "Containerd" field in /info was added in API 1.46

### daemon: move filling ContainerdInfo to fillContainerdInfo

Move it to a separate function; while the intended purpose is
for debugging, it does not have to be in the same function
that fills the debug information.

Also pass the daemon configuration that's already present,
instead of fetching it separately.

### api: swagger: move examples per-field, and update descriptions

- move the example-values per-field to prevent the example response
  getting out of sync with the actual struct.
- add default values for each field (although these are configurable)
- add some wording about these values being configurable, but not
  generally recommended to be changed.

### api/types/system: ContainerdNamespaces: update GoDoc

Update the GoDoc of this struct with a description similar to what's
used in the swagger.

### api/server/router/system: hide Containerd field on API < 1.46

This field was introduced in API 1.46, and should not be returned on
older API versions.

### docs/api: update version history